### PR TITLE
Fix flashing stock recovery zip rom

### DIFF
--- a/recovery/root/init.recovery.mt6833.rc
+++ b/recovery/root/init.recovery.mt6833.rc
@@ -46,6 +46,10 @@ on post-fs
     symlink /dev/block/platform/bootdevice/by-name/preloader_a /dev/block/by-name/preloader_ufs_a
     symlink /dev/block/platform/bootdevice/by-name/preloader_b /dev/block/by-name/preloader_ufs_b
 
+    # Fix flashing stock xiaomi recovery zip
+    symlink /dev/block/mapper/pl_a /dev/block/by-name/preloader_raw_a
+    symlink /dev/block/mapper/pl_b /dev/block/by-name/preloader_raw_b
+
     symlink /dev/block/platform/bootdevice /dev/block/bootdevice
 
     exec u:r:update_engine:s0 root root -- /system/bin/mtk_plpath_utils


### PR DESCRIPTION
I believe the other preloader path is useless, but I will leave it as it is.